### PR TITLE
DOC: Remove obsolete note mentioning extension is not available on macOS

### DIFF
--- a/index.md
+++ b/index.md
@@ -9,6 +9,4 @@ SlicerAutoscoperM (SAM) is a free, open source and multi-platform [3D Slicer](ht
 
 SAM is a single software package based on [Autoscoper](https://github.com/BrownBiomechanics/autoscoper) that enables the 3D tracking of structures within multiple imaging modalities including single, bi-, and multi-plane videoradiography, sequential CT volume images, 4DCT image volumes sets, and MRI volume sets. SAM will be built by updating and refining Autoscoper which is a bi-plane video radiography image registration software developed at Brown University, and then integrating it into the 3DSlicer ecosystem.
 
-**Note:** SAM is available for Windows and Linux operating systems, with MacOS support currently in development.
-
 ![Autoscoper Main Window](https://github.com/BrownBiomechanics/Autoscoper/releases/download/docs-resources/tutorial_AutoscoperMainWindow.png)


### PR DESCRIPTION
This should be merged only after these pull-requests have been integrated:
* https://github.com/BrownBiomechanics/Autoscoper/pull/136 
* https://github.com/BrownBiomechanics/SlicerAutoscoperM/pull/35
* https://github.com/BrownBiomechanics/Autoscoper/pull/137