### PR TITLE
BUG: Fix rendering of "ASB 2023 Symposium" QR Code on deployed site

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -22,7 +22,7 @@ description: >- # this means to ignore newlines until "baseurl:"
 #  line in _config.yml. It will appear in your document head meta (for
 #  Google search results) and in your feed.xml site description.
 baseurl: "" # the subpath of your site, e.g. /blog
-url: "autoscoperm.slicer.org" # the base hostname & protocol for your site, e.g. http://example.com
+url: "https://autoscoperm.slicer.org" # the base hostname & protocol for your site, e.g. http://example.com
 #twitter_username: jekyllrb
 github_username:  BrownBiomechanics
 


### PR DESCRIPTION
Update "url" settings to include the protocol

```diff
- <img alt="ASB 2023 Survey QR Code" src="autoscoperm.slicer.org/images/2023-08-09-asb-2023-symposium-questionnaire-qr-code.png">
+ <img alt="ASB 2023 Survey QR Code" src="https://autoscoperm.slicer.org/images/2023-08-09-asb-2023-symposium-questionnaire-qr-code.png">
```