### PR TITLE
ENH: Modernize About page layout using CSS Grid and Font Awesome icons

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -1,0 +1,11 @@
+<head>
+  <meta charset="utf-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  {%- seo -%}
+  <link rel="stylesheet" href="{{ "/assets/main.css" | relative_url }}">
+  {%- feed_meta -%}
+  {%- if jekyll.environment == 'production' and site.google_analytics -%}
+    {%- include google-analytics.html -%}
+  {%- endif -%}
+</head>

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -2,6 +2,7 @@
   <meta charset="utf-8">
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <meta name="viewport" content="width=device-width, initial-scale=1">
+  <script defer src="https://use.fontawesome.com/releases/v5.15.4/js/all.js"></script>
   {%- seo -%}
   <link rel="stylesheet" href="{{ "/assets/main.css" | relative_url }}">
   {%- feed_meta -%}

--- a/about.md
+++ b/about.md
@@ -9,44 +9,67 @@ Free, open source 3D Slicer extension for image-based 3D motion tracking of skel
 
 Integrating advanced videoradiography, 4DCT registration, and hierarchical 3D registration for cutting-edge biomechanical research
 
-<table>
-  <tr>
-      <td>
-        <h3>Discourse</h3>
-      </td>
-      <td>
-        <h3>GitHub Repository</h3>
-      </td>
-      <td>
-        <h3>Documentation</h3>
-      </td>
-  </tr>
+<style>
+  .resource-grid {
+    display: grid;
+    grid-template-columns: 1fr 1fr 1fr;
+    gap: 1.5rem;
+    justify-content: space-around;
+    margin-top: 2rem;
+  }
 
-  <tr>
-    <td>
-      Join the community and get answers to your questions
-    </td>
-    <td>
-      Access source code, report issues, and contribute to development
-    </td>
-    <td>
-      Comprehensive guides, tutorials, and API documentation
-    </td>
-  </tr>
+  .resource-card {
+    border: 1px solid #e0e0e0;
+    border-radius: 8px;
+    padding: 1rem;
+    text-align: center;
+    background-color: #fafafa;
+    box-shadow: 0 2px 4px rgba(0,0,0,0.05);
+  }
 
-  <tr>
-    <td>
-      <button name="discourse" onclick="href ='https://discourse.slicer.org/c/community/slicerautoscoperm/30'">Discourse</button>
-    </td>
-    <td>
-      <button name="github" onclick="href ='https://github.com/BrownBiomechanics'">View Code</button>
-    </td>
-    <td>
-      <button name="readthedocs" onclick="href ='https://autoscoper.readthedocs.io/'">Read Docs</button>
-    </td>
-  </tr>
-</table>
+  .resource-card i {
+    font-size: 2rem;
+    margin-bottom: 0.5rem;
+    color: #333;
+  }
+</style>
 
+<div class="resource-grid">
+  <div class="resource-card">
+    <i class="fas fa-comments"></i>
+    <h4>Discourse</h4>
+    <p>Join the community and get answers to your questions.</p>
+    <p>
+      <a href="https://discourse.slicer.org/c/community/slicerautoscoperm/30" target="_blank">
+        Visit Forum →
+      </a>
+    </p>
+  </div>
+
+  <div class="resource-card">
+    <i class="fab fa-github"></i>
+    <h4>GitHub Repository</h4>
+    <p>Access source code, report issues, and contribute to development.</p>
+    <p>
+      <a href="https://github.com/BrownBiomechanics" target="_blank">
+        Go to GitHub →
+      </a>
+    </p>
+  </div>
+
+  <div class="resource-card">
+    <i class="fas fa-book-open"></i>
+    <h4>Documentation</h4>
+    <p>Comprehensive guides, tutorials, and API documentation.</p>
+    <p>
+      <a href="https://autoscoper.readthedocs.io/" target="_blank">
+        Read Docs →
+      </a>
+    </p>
+  </div>
+</div>
+
+<br/>
 
 * [Team]({% link team.md %})
 * [License](https://autoscoper.readthedocs.io/en/latest/about.html#license)


### PR DESCRIPTION
Replaces the HTML `<table>`-based layout with a responsive CSS Grid layout.

Each resource (Discourse, GitHub, Documentation) is now presented as a styled card with Font Awesome icons.

| Before | After |
|--|--|
| <img width="800" height="601" alt="image" src="https://github.com/user-attachments/assets/4632474d-97df-4719-aec1-81082ff59149" /> | <img width="791" height="624" alt="image" src="https://github.com/user-attachments/assets/82b6cb57-be43-4bc8-9d14-b1ed67fdea10" /> |

